### PR TITLE
为 `SettingsSliderPiece` 滑块添加悬停提示线

### DIFF
--- a/osu.Game.Rulesets.Hikariii/Features/Player/Graphics/SideBar/Settings/Items/SettingsListPiece.cs
+++ b/osu.Game.Rulesets.Hikariii/Features/Player/Graphics/SideBar/Settings/Items/SettingsListPiece.cs
@@ -19,7 +19,9 @@ namespace osu.Game.Rulesets.Hikariii.Features.Player.Graphics.SideBar.Settings.I
 
         private readonly CurrentValueText valueText = new CurrentValueText
         {
-            RelativeSizeAxes = Axes.X
+            RelativeSizeAxes = Axes.X,
+            Anchor = Anchor.CentreLeft,
+            Origin = Anchor.CentreLeft,
         };
 
         public List<T> Values { get; set; }
@@ -83,7 +85,9 @@ namespace osu.Game.Rulesets.Hikariii.Features.Player.Graphics.SideBar.Settings.I
                         Alpha = 0,
                         Font = OsuFont.GetFont(size: 20),
                         Y = -5,
-                        RelativeSizeAxes = Axes.X
+                        RelativeSizeAxes = Axes.X,
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
                     };
 
                     Schedule(() => AddInternal(currentText));

--- a/osu.Game.Rulesets.Hikariii/Features/Player/Graphics/SideBar/Settings/Items/SettingsPieceBasePanel.cs
+++ b/osu.Game.Rulesets.Hikariii/Features/Player/Graphics/SideBar/Settings/Items/SettingsPieceBasePanel.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Rulesets.Hikariii.Features.Player.Graphics.SideBar.Settings.I
             Size = new Vector2(25)
         };
 
+        protected GridContainer FirstLineGrid { get; private set; }
+
         public virtual LocalisableString Description
         {
             get => description;
@@ -91,14 +93,6 @@ namespace osu.Game.Rulesets.Hikariii.Features.Player.Graphics.SideBar.Settings.I
                     RelativeSizeAxes = Axes.Both,
                     Depth = float.MaxValue
                 },
-                new Container
-                {
-                    RelativeSizeAxes = Axes.X,
-                    Height = 25,
-                    Margin = new MarginPadding { Top = 10 },
-                    Padding = new MarginPadding { Left = 10 + 25 + 5 },
-                    Child = CreateSideDrawable()
-                },
                 FillFlow = new FillFlowContainer
                 {
                     AutoSizeAxes = Axes.Y,
@@ -108,7 +102,33 @@ namespace osu.Game.Rulesets.Hikariii.Features.Player.Graphics.SideBar.Settings.I
                     Spacing = new Vector2(5),
                     Children = new Drawable[]
                     {
-                        SpriteIcon,
+                        FirstLineGrid = new GridContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            RowDimensions = [new Dimension(GridSizeMode.AutoSize)],
+                            ColumnDimensions =
+                            [
+                                new Dimension(GridSizeMode.AutoSize),
+                                new Dimension(),
+                            ],
+                            Content = new[]
+                            {
+                                new Drawable[]
+                                {
+                                    SpriteIcon,
+                                    CreateSideDrawable().With(d =>
+                                    {
+                                        d.Anchor = Anchor.CentreLeft;
+                                        d.Origin = Anchor.CentreLeft;
+                                        d.Margin = new MarginPadding
+                                        {
+                                            Horizontal = 5,
+                                        };
+                                    }),
+                                },
+                            },
+                        },
                         SpriteText,
                     }
                 },

--- a/osu.Game.Rulesets.Hikariii/Features/Player/Graphics/SideBar/Settings/Items/SettingsSeparatorPiece.cs
+++ b/osu.Game.Rulesets.Hikariii/Features/Player/Graphics/SideBar/Settings/Items/SettingsSeparatorPiece.cs
@@ -21,10 +21,10 @@ namespace osu.Game.Rulesets.Hikariii.Features.Player.Graphics.SideBar.Settings.I
             RelativeSizeAxes = Axes.X;
             Width = 1;
 
-            SpriteText.Anchor = SpriteText.Origin = SpriteIcon.Anchor = SpriteIcon.Origin = Anchor.BottomRight;
+            SpriteText.Anchor = SpriteText.Origin = FirstLineGrid.Anchor = FirstLineGrid.Origin = Anchor.BottomRight;
             FillFlow.Direction = FillDirection.Horizontal;
 
-            SpriteIcon.Hide();
+            FirstLineGrid.Hide();
         }
 
         protected override void OnColorChanged()

--- a/osu.Game.Rulesets.Hikariii/Features/Player/Graphics/SideBar/Settings/Items/SettingsSlider.cs
+++ b/osu.Game.Rulesets.Hikariii/Features/Player/Graphics/SideBar/Settings/Items/SettingsSlider.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Rulesets.Hikariii.Features.Player.Graphics.SideBar.Settings.I
         protected override void UpdateValue(float value)
         {
             circle.MoveToX(value, 250, Easing.OutExpo);
-            circle.ScaleTo(value + 0.2f, 250, Easing.OutBack);
+            circle.ScaleTo(value * 0.75f + 0.25f, 250, Easing.OutBack);
         }
     }
 }

--- a/osu.Game.Rulesets.Hikariii/Features/Player/Graphics/SideBar/Settings/Items/SettingsSlider.cs
+++ b/osu.Game.Rulesets.Hikariii/Features/Player/Graphics/SideBar/Settings/Items/SettingsSlider.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Numerics;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -14,29 +15,67 @@ namespace osu.Game.Rulesets.Hikariii.Features.Player.Graphics.SideBar.Settings.I
     public partial class SettingsSlider<T> : OsuSliderBar<T>
         where T : struct, INumber<T>, IMinMaxValue<T>, IConvertible
     {
+        /// <summary>
+        /// Controls whether to show a hint line below the slider body.
+        /// </summary>
+        public readonly BindableBool HintActive = new BindableBool();
+
+        private Circle baseLine;
         private Container circle;
 
         [BackgroundDependencyLoader]
         private void load()
         {
             Height = 1;
-            Child = circle = new Container
+
+            Children = new Drawable[]
             {
-                RelativePositionAxes = Axes.X,
-                Size = new Vector2(25),
-                Anchor = Anchor.CentreLeft,
-                Origin = Anchor.CentreLeft,
-                Child = new Circle
+                baseLine = new Circle
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.X,
+                    Height = 2,
+                    Alpha = 0,
+                },
+                circle = new Container
+                {
                     RelativePositionAxes = Axes.X,
-                    X = -0.5f
+                    Size = new Vector2(25),
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Child = new Circle
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        RelativePositionAxes = Axes.X,
+                        X = -0.5f
+                    }
                 }
             };
 
             RangePadding = 0;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            HintActive.BindValueChanged(onLineStatusChanged);
+        }
+
+        private void onLineStatusChanged(ValueChangedEvent<bool> e)
+        {
+            if (e.NewValue)
+            {
+                baseLine.ResizeHeightTo(4, 250, Easing.OutExpo);
+                baseLine.FadeTo(0.8f, 250, Easing.OutExpo);
+            }
+            else
+            {
+                baseLine.ResizeHeightTo(2, 250, Easing.OutExpo);
+                baseLine.FadeOut(250, Easing.OutExpo);
+            }
         }
 
         protected override void UpdateValue(float value)

--- a/osu.Game.Rulesets.Hikariii/Features/Player/Graphics/SideBar/Settings/Items/SettingsSliderPiece.cs
+++ b/osu.Game.Rulesets.Hikariii/Features/Player/Graphics/SideBar/Settings/Items/SettingsSliderPiece.cs
@@ -2,9 +2,11 @@
 
 using System;
 using System.Numerics;
+using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 
 namespace osu.Game.Rulesets.Hikariii.Features.Player.Graphics.SideBar.Settings.Items
@@ -27,7 +29,7 @@ namespace osu.Game.Rulesets.Hikariii.Features.Player.Graphics.SideBar.Settings.I
 
         protected override IconUsage DefaultIcon => FontAwesome.Solid.SlidersH;
 
-        protected override Drawable CreateSideDrawable() => new SettingsSlider<T>
+        protected override Drawable CreateSideDrawable() => slider = new SettingsSlider<T>
         {
             RelativeSizeAxes = Axes.Both,
             Current = Bindable,
@@ -35,9 +37,28 @@ namespace osu.Game.Rulesets.Hikariii.Features.Player.Graphics.SideBar.Settings.I
             TransferValueOnCommit = TransferValueOnCommit,
         };
 
+        [CanBeNull]
+        private SettingsSlider<T> slider;
+
         protected override void OnMiddleClick()
         {
             Bindable.Value = Bindable.Default;
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            if (slider != null)
+                slider.HintActive.Value = true;
+
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            if (slider != null)
+                slider.HintActive.Value = false;
+
+            base.OnHoverLost(e);
         }
     }
 }


### PR DESCRIPTION
悬停时在滑块下方显示参考线，便于更好地估测与调节数值。

## 相关修改

- `SettingsPieceBasePanel` 中原先浮动的附加组件现已与图标合并到一个网格容器 (`FirstLineGrid`) 中，以保证大小分配与对齐
- `CreateSideDrawable()` 调用时会自动加上侧边 Margin
